### PR TITLE
fix(posts/view): wrong ioc import crashing the view

### DIFF
--- a/src/ui/features/posts/views/create_post_page/create_post_page.tsx
+++ b/src/ui/features/posts/views/create_post_page/create_post_page.tsx
@@ -6,7 +6,7 @@ import { Switch } from "@/src/ui/components/switch/switch";
 import { useAsyncState } from "@front_web_mrmilu/hooks";
 import type { CreatePostUseCase } from "@/src/core/posts/domain/use_cases/create_post_use_case";
 import css from "./create_post_page.css";
-import { locator } from "@/src/core/app/ioc/__generated__/";
+import { locator } from "@/src/core/app/ioc/__generated__";
 import { TYPES } from "@/src/core/app/ioc/__generated__/types";
 
 export default function CreatePostPage() {


### PR DESCRIPTION
While trying out the React project I encountered this issue caused by a wrong import.

| Before        | After           |
| ------------- |:-------------:|
| <img width="1794" alt="image" src="https://github.com/mrmilu/react.base/assets/5566452/e2c90f91-cec8-416a-b9a5-cafea1b38b86">      | <img width="1785" alt="image" src="https://github.com/mrmilu/react.base/assets/5566452/f95500ad-c1e7-4ff9-a91c-0f3205fac36d"> |